### PR TITLE
Implemented Flags `center` and `quick`

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,51 @@ import { CliFlagsType } from './cli';
 import { Field } from './components/Field';
 import { useGameStore } from './state/state';
 import { MainMenu } from './components/MainMenu';
-import { CustomFieldMenu } from './components/CustomFieldMenu';
+import {
+  CustomFieldMenu,
+  maxHeight,
+  maxWidth,
+  minMines,
+  minHeight,
+  minWidth,
+  getMaxMines,
+} from './components/CustomFieldMenu';
 import { Box } from 'ink';
 
-export const App: FC<CliFlagsType> = ({ legacy }) => {
+export const App: FC<CliFlagsType> = ({ legacy, center, quick }) => {
   const switchDrawingMode = useGameStore((s) => s.switchDrawingMode);
   useEffect(() => {
     legacy && switchDrawingMode();
   }, [legacy, switchDrawingMode]);
+  const startGame = useGameStore((s) => s.startGame);
+
+  const getQuickGame = (quick:string): [number, number, number] => {
+    if (quick) {
+      const dims = quick.split(`,`);
+      if (dims.length == 3) {
+        return [+dims[0], +dims[1], +dims[2]];
+      }
+    }
+  };
+
+  const getAlignment = (center:boolean) => (center ? `center` : `flex-start`);
+
+  useEffect(() => {
+    const dims = getQuickGame(quick);
+    dims &&
+      dims[0] > minWidth &&
+      dims[0] < maxWidth &&
+      dims[1] > minHeight &&
+      dims[1] < maxHeight &&
+      dims[2] > minMines &&
+      dims[2] < getMaxMines(dims[0], dims[1]) &&
+      startGame(`custom`, { width: dims[0], height: dims[1], mines: dims[2] });
+  }, [quick, startGame]);
+
   const gameStatus = useGameStore((s) => s.gameStatus);
+
   return (
-    <Box marginLeft={2} marginTop={1} flexDirection={`column`}>
+    <Box alignItems={getAlignment(center)} marginLeft={2} marginRight={2} marginTop={1} flexDirection={`column`} >
       {gameStatus === `startScreen` ? (
         <MainMenu />
       ) : gameStatus === `customFieldSetup` ? (

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -11,12 +11,25 @@ Options:
 
   --legacy, -L
 	    Legacy mode. Use this if your terminal doesn't support emojis
+  --center, -C
+        Use this flag to align the game to the center of the terminal
+  --quick, -Q
+        Enter a custom game directly with width, height and mines as 'width,height,mines'
 `,
   {
     flags: {
       legacy: {
         type: `boolean`,
         alias: `L`,
+      },
+      center: {
+        type: `boolean`,
+        alias: `C`,
+        default: false,
+      },
+      quick: {
+        type: `string`,
+        alias: `Q`,
       },
     },
   }

--- a/src/components/CustomFieldMenu.tsx
+++ b/src/components/CustomFieldMenu.tsx
@@ -3,12 +3,12 @@ import { Box, Text, useInput } from 'ink';
 import { CustomConfigType, useGameStore } from '../state/state';
 import TextInput from 'ink-text-input';
 
-const minWidth = 5;
-const maxWidth = 50;
-const minHeight = 5;
-const maxHeight = 25;
-const minMines = 1;
-const getMaxMines = (width: number, height: number) => Math.floor(width * height * 0.6);
+export const minWidth = 5;
+export const maxWidth = 50;
+export const minHeight = 5;
+export const maxHeight = 25;
+export const minMines = 1;
+export const getMaxMines = (width: number, height: number): number => Math.floor(width * height * 0.6);
 
 export const CustomFieldMenu: React.FC = () => {
   const [config, setConfig] = useState<Partial<CustomConfigType>>({});


### PR DESCRIPTION
`center` aligns all elements horizantically in the center
`quick` allows a start configuration to skip the main menu and enter a custom game directly.

I have never touched typescript or react, but wanted to try and fiddle with the code a little. This is probably quite the bad code but it manages to center the game in the terminal and it allows me to start a game directly from the command line.

If you have an opinion about the code changes, let me know. I didn't understand a third of what I was doing.